### PR TITLE
Work around "OPENSSL_Uplink: no OPENSSL_Applink" runtime error when u…

### DIFF
--- a/linux-and-macOS/alrng/api-inc/AlphaRngApi.h
+++ b/linux-and-macOS/alrng/api-inc/AlphaRngApi.h
@@ -81,6 +81,7 @@ public:
 	bool noise_to_file(const string &file_path_name, int64_t num_bytes);
 	HealthTests get_health_tests() {return m_health_test;}
 	int get_operation_retry_count() {return m_op_retry_count;}
+	AlphaRngConfig& get_configuration() { return m_cfg; }
 
 	virtual	~AlphaRngApi();
 	bool is_initialized() {return m_is_initialized;}

--- a/linux-and-macOS/alrng/api-inc/RsaCryptor.h
+++ b/linux-and-macOS/alrng/api-inc/RsaCryptor.h
@@ -16,7 +16,7 @@
  *    @file RsaCryptor.h
  *    @date 01/10/2020
  *    @Author: Andrian Belinski
- *    @version 1.0
+ *    @version 1.1
  *
  *    @brief Used for establishing a secure session between the host computer and the AlphaRNG device suing RSA PK encryption.
  */
@@ -27,6 +27,7 @@
 #include <openssl/rsa.h>
 #include <openssl/pem.h>
 #include <string>
+#include <fstream>
 
 using namespace std;
 
@@ -48,15 +49,17 @@ public:
 	bool is_public_key_file() {return m_is_public_key_file;}
 	virtual ~RsaCryptor();
 private:
-	void initialize();
 	void crete_new_key(int key_size);
+	void initialize_with_key(const unsigned char* key, int key_size_bytes, bool is_public);
 private:
     RSA *m_rsa = nullptr;
     BIO *m_kbio_rsa = nullptr;
     BIGNUM *m_bignum = nullptr;
     bool m_is_key_initialized = false;
-    int m_padding;
+    int m_padding = RSA_NO_PADDING;
     bool m_is_public_key_file = false;
+	unsigned char* m_file_pub_key_bytes = nullptr;
+	const int c_m_file_pub_key_max_size_bytes = 1024*2;
 };
 
 } /* namespace alpharng */

--- a/windows-x64/api/AlphaRngApi.h
+++ b/windows-x64/api/AlphaRngApi.h
@@ -81,6 +81,7 @@ public:
 	bool noise_to_file(const string &file_path_name, int64_t num_bytes);
 	HealthTests get_health_tests() {return m_health_test;}
 	int get_operation_retry_count() {return m_op_retry_count;}
+	AlphaRngConfig& get_configuration() { return m_cfg; }
 
 	virtual	~AlphaRngApi();
 	bool is_initialized() {return m_is_initialized;}

--- a/windows-x64/api/RsaCryptor.h
+++ b/windows-x64/api/RsaCryptor.h
@@ -16,7 +16,7 @@
  *    @file RsaCryptor.h
  *    @date 01/10/2020
  *    @Author: Andrian Belinski
- *    @version 1.0
+ *    @version 1.1
  *
  *    @brief Used for establishing a secure session between the host computer and the AlphaRNG device suing RSA PK encryption.
  */
@@ -27,6 +27,7 @@
 #include <openssl/rsa.h>
 #include <openssl/pem.h>
 #include <string>
+#include <fstream>
 
 using namespace std;
 
@@ -48,15 +49,17 @@ public:
 	bool is_public_key_file() {return m_is_public_key_file;}
 	virtual ~RsaCryptor();
 private:
-	void initialize();
 	void crete_new_key(int key_size);
+	void initialize_with_key(const unsigned char* key, int key_size_bytes, bool is_public);
 private:
     RSA *m_rsa = nullptr;
     BIO *m_kbio_rsa = nullptr;
     BIGNUM *m_bignum = nullptr;
     bool m_is_key_initialized = false;
-    int m_padding;
+    int m_padding = RSA_NO_PADDING;
     bool m_is_public_key_file = false;
+	unsigned char* m_file_pub_key_bytes = nullptr;
+	const int c_m_file_pub_key_max_size_bytes = 1024*2;
 };
 
 } /* namespace alpharng */

--- a/windows-x64/entropy-client-sample/entropy-client-sample.cpp
+++ b/windows-x64/entropy-client-sample/entropy-client-sample.cpp
@@ -25,7 +25,7 @@ int main() {
 	cout << "--- Sample C++ program for retrieving random bytes from the entropy server ---" << endl;
 	cout << "------------------------------------------------------------------------------" << endl;
 
-	// Connecting to the first AlphaRNG device found
+	// Connecting to the entropy server
 	if (!pipe.open_named_pipe()) {
 		cerr << pipe.get_last_error() << endl;
 		cerr << "Is entropy server running?" << endl;


### PR DESCRIPTION
Work around "OPENSSL_Uplink: no OPENSSL_Applink" runtime error when using alrng.exe and entropy-server.exe with Windows