### PR TITLE
Add compatibility with older MacbookPro laptops

### DIFF
--- a/linux-and-macOS/alrng/alperftest.cpp
+++ b/linux-and-macOS/alrng/alperftest.cpp
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2014-2023 TectroLabs L.L.C. https://tectrolabs.com
+ Copyright (C) 2014-2024 TectroLabs L.L.C. https://tectrolabs.com
 
  THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
  INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
@@ -13,9 +13,9 @@
 
 /**
  *    @file alperftest.cpp
- *    @date 9/16/2023
+ *    @date 1/9/2024
  *    @Author: Andrian Belinski
- *    @version 1.3
+ *    @version 1.4
  *
  *    @brief A utility used for measuring performance of the AlphaRNG device in different transmission modes.
  */

--- a/linux-and-macOS/alrng/alrng.cpp
+++ b/linux-and-macOS/alrng/alrng.cpp
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2014-2023 TectroLabs L.L.C. https://tectrolabs.com
+ Copyright (C) 2014-2024 TectroLabs L.L.C. https://tectrolabs.com
 
  THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
  INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
@@ -13,9 +13,9 @@
 
 /**
  *    @file alrng.cpp
- *    @date 11/18/2023
+ *    @date 1/9/2024
  *    @Author: Andrian Belinski
- *    @version 2.0
+ *    @version 2.1
  *
  *    @brief A utility used for downloading data from the AlphaRNG device
  */
@@ -54,7 +54,7 @@ AppArguments appArgs ({
 /**
 * Current version of this utility application
 */
-static double const version = 2.0;
+static double const version = 2.1;
 
 /**
 * Local functions used

--- a/linux-and-macOS/alrng/alrngdiag.cpp
+++ b/linux-and-macOS/alrng/alrngdiag.cpp
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2014-2023 TectroLabs L.L.C. https://tectrolabs.com
+ Copyright (C) 2014-2024 TectroLabs L.L.C. https://tectrolabs.com
 
  THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
  INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
@@ -13,9 +13,9 @@
 
 /**
  *    @file alrngdiag.cpp
- *    @date 09/16/2023
+ *    @date 1/9/2024
  *    @Author: Andrian Belinski
- *    @version 1.4
+ *    @version 1.5
  *
  *    @brief A utility used for running the AlphaRNG device diagnostics
  *

--- a/linux-and-macOS/alrng/api-src/UsbSerialDevice.cpp
+++ b/linux-and-macOS/alrng/api-src/UsbSerialDevice.cpp
@@ -1,4 +1,4 @@
-/**1 Copyright (C) 2014-2023 TectroLabs L.L.C. https://tectrolabs.com
+/**1 Copyright (C) 2014-2024 TectroLabs L.L.C. https://tectrolabs.com
 
  THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
  INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
@@ -11,9 +11,9 @@
 
 /**
  *    @file UsbSerialDevice.cpp
- *    @date 9/16/2023
+ *    @date 1/9/2024
  *    @Author: Andrian Belinski
- *    @version 1.2
+ *    @version 1.3
  *
  *    @brief Implements the API for communicating with the CDC USB interface
  */
@@ -221,7 +221,7 @@ void UsbSerialDevice::scan_available_devices() {
 #ifdef __linux__
 	char command[] = "/bin/ls -1l /dev/serial/by-id 2>&1 | grep -i \"TectroLabs_Alpha_RNG\"";
 #else
-	char command[] = "/bin/ls -1a /dev/cu.usbmodemALPHARNG* /dev/cu.usbmodemFD* 2>&1";
+	char command[] = "/bin/ls -1a /dev/cu.usbmodemALPHARNG* /dev/cu.usbmodemF* 2>&1";
 #endif
 	FILE *pf = popen(command,"r");
 	if (pf == nullptr) {
@@ -237,7 +237,7 @@ void UsbSerialDevice::scan_available_devices() {
 		}
 #else
 		int cmp1  = strncmp(line, "/dev/cu.usbmodemALPHARNG", 24);
-		int cmp2  = strncmp(line, "/dev/cu.usbmodemFD", 18);
+		int cmp2  = strncmp(line, "/dev/cu.usbmodemF", 17);
 		if (cmp1 != 0 && cmp2 != 0 ) {
 			continue;
 		}

--- a/linux-and-macOS/alrng/sample.cpp
+++ b/linux-and-macOS/alrng/sample.cpp
@@ -1,3 +1,11 @@
+/**
+ *    @file sample.cpp
+ *    @date 1/9/2024
+ *    @version 1.0
+ *
+ *    @brief A C++ example using C++ API for communicating with the AlphaRNG device.
+ */
+
 #include <AlphaRngApi.h>
 #include <array>
 
@@ -11,7 +19,7 @@ int main() {
 
     //A sample code that retrieves entropy bytes from an AlphaRNG device and store those into a file
 
-    // Create a new AlphaRngApi instance using default constructor (using HMAC-SHA256, RSA2048, and AES-256-GCM)
+    // Create a new AlphaRngApi instance using default constructor (HMAC-SHA256, RSA2048, and AES-256-GCM)
     AlphaRngApi rng { };
 
     // Connecting to the first AlphaRNG device found

--- a/linux-and-macOS/alrng/sample_c.c
+++ b/linux-and-macOS/alrng/sample_c.c
@@ -1,7 +1,7 @@
 /**
- *    @file sample.c
- *    @date 09/16/2023
- *    @version 1.3
+ *    @file sample_c.c
+ *    @date 1/9/2024
+ *    @version 1.4
  *
  *    @brief A C example that utilizes a C wrapper around the C++ API for communicating with the AlphaRNG device.
  */


### PR DESCRIPTION
Updates to support older macOS versions such as 'macOS High Sierra' (Version 10.13.6)